### PR TITLE
Do not cut the lower portion of larger icons in the banner above the page

### DIFF
--- a/icon.php
+++ b/icon.php
@@ -105,7 +105,7 @@ function icon_large($pct,$score,$fixmes){
     $w   = imagesx($ico);
     $h   = imagesy($ico);
     imageSaveAlpha($ico, true);
-    imagecopy($img,$ico,$x,4,0,0,$w,$h);
+    imagecopy($img,$ico,$x,($OPTS['height']-$h)/2,0,0,$w,$h);
     imagedestroy($ico);
     $x += $w;
 
@@ -119,7 +119,7 @@ function icon_large($pct,$score,$fixmes){
         $w   = imagesx($ico);
         $h   = imagesy($ico);
         imageSaveAlpha($ico, true);
-        imagecopy($img,$ico,$x,4,0,0,$w,$h);
+        imagecopy($img,$ico,$x,($OPTS['height']-$h)/2,0,0,$w,$h);
         imagedestroy($ico);
         $x += $w;
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,7 +2,7 @@
 base   qc
 author Andreas Gohr
 email  dokuwiki@cosmocode.de
-date   2015-02-26
+date   2015-03-09
 name   Quality Control Plugin
 desc   Check the page structure for quality problems
 url    http://www.dokuwiki.org/plugin:qc


### PR DESCRIPTION
The 4px works well for the default theme and ok-ish for the icke-wiki
theme but it breaks some custom icons. The method in this commit should
always keep the icon centered horizontally.