### PR TITLE
Get the correct authors of a page

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -64,7 +64,8 @@ class renderer_plugin_qc extends Doku_Renderer {
         $this->doc['modified'] = $meta['date']['modified'];
 
         // get author info
-        $revs = getRevisions($ID,0,0);
+        $changelog = new PageChangelog($ID);
+        $revs = $changelog->getRevisions(0,10000); //FIXME find a good solution for 'get ALL revisions'
         array_push($revs,$meta['last_change']['date']);
         $this->doc['changes'] = count($revs);
         foreach($revs as $rev){


### PR DESCRIPTION
Use a `PageChangelog` instance and get the revisions from there. Also get the last 10.000 revisions and not just the last one.

10.000 is an arbitrary number here and I would prefer something like "get all revisions". If that's not sensible or possible, what would be a good number and why?