### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -38,7 +38,7 @@ class action_plugin_qc extends DokuWiki_Action_Plugin {
      *
      * we need hook the indexer to trigger the cleanup
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('INDEXER_TASKS_RUN', 'BEFORE', $this, 'qccron', array());
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -34,13 +34,13 @@ class syntax_plugin_qc extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~NOQC~~',$mode,'plugin_qc');
     }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array();
 
         return $data;
     }
 
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if($mode != 'metadata') return false;
 
         $R->meta['relation']['qcplugin_disabled'] = true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.