### PR TITLE
fix broken request if DOKU_BASE is '/'

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@ jQuery(function () {
 
     // autoload the summary
     jQuery.post(
-        DOKU_BASE + '/lib/exe/ajax.php',
+        DOKU_BASE + 'lib/exe/ajax.php',
         {
             call: 'plugin_qc_short',
             id: JSINFO['id']
@@ -24,7 +24,7 @@ jQuery(function () {
             $output.html('loading...');
 
             jQuery.post(
-                DOKU_BASE + '/lib/exe/ajax.php',
+                DOKU_BASE + 'lib/exe/ajax.php',
                 {
                     call: 'plugin_qc_long',
                     id: JSINFO['id']


### PR DESCRIPTION
If `DOKU_BASE` is `/` then it would result in an URL with leading `//`, which is interpreted as protocol-relative.

SPR-869