### PR TITLE
align url

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -5,4 +5,4 @@ email  dokuwiki@cosmocode.de
 date   2023-12-02
 name   Quality Control Plugin
 desc   Check the page structure for quality problems
-url    http://www.dokuwiki.org/plugin:qc
+url    https://www.dokuwiki.org/plugin:qc


### PR DESCRIPTION
Provide standard url prefix to `plugin.info.txt`
ref [standard URL prefix for plug-ins](https://forum.dokuwiki.org/d/22212-standard-url-prefix-for-plug-ins)