### PR TITLE
apply some flexibility improvements

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -77,10 +77,15 @@ class admin_plugin_qc extends AdminPlugin
             '<a href="' . wl($ID, ['do' => 'admin', 'page' => 'qc', 'pluginqc[order]' => 'fixme']) . '">' .
             $this->getLang('admin_fixme') . '</a></th>';
         echo '  </tr>';
-
+        
+        $skip = $this->getConf('ignore_sidebar');
+        
         if ($this->data) {
             foreach ($this->data as $id => $data) {
                 if ($max == 0) break;
+                if ($skip && str_ends_with($id, 'sidebar')) {
+                    continue;  // skips 'sidebar' special pages
+                }
                 echo '  <tr>';
                 echo '    <td>';
                 tpl_pagelink(':' . $id, $id);

--- a/admin.php
+++ b/admin.php
@@ -78,7 +78,7 @@ class admin_plugin_qc extends AdminPlugin
             $this->getLang('admin_fixme') . '</a></th>';
         echo '  </tr>';
         
-        $skip = $this->getConf('ignore_sidebar');
+        $skip = $this->getConf('skip_sidebar');
         
         if ($this->data) {
             foreach ($this->data as $id => $data) {

--- a/conf/default.php
+++ b/conf/default.php
@@ -3,3 +3,4 @@
 $conf['maxshowen'] = '25';
 $conf['adminonly'] = 0;
 $conf['single_author_only'] = 0;
+$conf['ignore_nobacklink'] = 0;

--- a/conf/default.php
+++ b/conf/default.php
@@ -5,3 +5,4 @@ $conf['adminonly'] = 0;
 $conf['single_author_only'] = 0;
 $conf['ignore_nobacklink'] = 0;
 $conf['ignore_header_count'] = 0;
+$conf['ignore_todo-list'] = 0;

--- a/conf/default.php
+++ b/conf/default.php
@@ -6,3 +6,4 @@ $conf['single_author_only'] = 0;
 $conf['ignore_nobacklink'] = 0;
 $conf['ignore_header_count'] = 0;
 $conf['ignore_todo-list'] = 0;
+$conf['ignore_sidebar'] = 1;

--- a/conf/default.php
+++ b/conf/default.php
@@ -4,3 +4,4 @@ $conf['maxshowen'] = '25';
 $conf['adminonly'] = 0;
 $conf['single_author_only'] = 0;
 $conf['ignore_nobacklink'] = 0;
+$conf['ignore_header_count'] = 0;

--- a/conf/default.php
+++ b/conf/default.php
@@ -5,5 +5,5 @@ $conf['adminonly'] = 0;
 $conf['single_author_only'] = 0;
 $conf['ignore_nobacklink'] = 0;
 $conf['ignore_header_count'] = 0;
-$conf['ignore_todo-list'] = 0;
-$conf['ignore_sidebar'] = 1;
+$conf['skip_todo-list'] = 0;
+$conf['skip_sidebar'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,5 +5,5 @@ $meta['adminonly'] = array('onoff');
 $meta['single_author_only'] = array('onoff');
 $meta['ignore_nobacklink'] = array('onoff');
 $meta['ignore_header_count'] = array('onoff');
-$meta['ignore_todo-list'] = array('onoff');
-$meta['ignore_sidebar'] = array('onoff');
+$meta['skip_todo-list'] = array('onoff');
+$meta['skip_sidebar'] = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,3 +3,4 @@
 $meta['maxshowen'] = array('numeric');
 $meta['adminonly'] = array('onoff');
 $meta['single_author_only'] = array('onoff');
+$meta['ignore_nobacklink'] = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,3 +6,4 @@ $meta['single_author_only'] = array('onoff');
 $meta['ignore_nobacklink'] = array('onoff');
 $meta['ignore_header_count'] = array('onoff');
 $meta['ignore_todo-list'] = array('onoff');
+$meta['ignore_sidebar'] = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,3 +4,4 @@ $meta['maxshowen'] = array('numeric');
 $meta['adminonly'] = array('onoff');
 $meta['single_author_only'] = array('onoff');
 $meta['ignore_nobacklink'] = array('onoff');
+$meta['ignore_header_count'] = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,3 +5,4 @@ $meta['adminonly'] = array('onoff');
 $meta['single_author_only'] = array('onoff');
 $meta['ignore_nobacklink'] = array('onoff');
 $meta['ignore_header_count'] = array('onoff');
+$meta['ignore_todo-list'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -6,3 +6,4 @@ $lang['single_author_only'] = 'There is only one or a few authors.';
 $lang['ignore_nobacklink'] = 'Ignore the scoring of missing backlinks. This might be applicable when the Alternative Breadcrumbs feature is providing a backlink each for all pages e.g., by the sprintdoc template'
 $lang['ignore_header_count'] = 'Ignore the scoring of more than one H1 header.'
 $lang['ignore_todo-list'] = 'Ignore pages specifically marked with the "~~TODOLIST~~" macro for use with the ToDo plugin.'
+$lang['ignore_sidebar'] = 'Ignore "sidebar" special page names.'

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -5,3 +5,4 @@ $lang['adminonly'] = 'Quality Summary only visible for members of the admin grou
 $lang['single_author_only'] = 'There is only one or a few authors.';
 $lang['ignore_nobacklink'] = 'Ignore the scoring of missing backlinks. This might be applicable when the Alternative Breadcrumbs feature is providing a backlink each for all pages e.g., by the sprintdoc template'
 $lang['ignore_header_count'] = 'Ignore the scoring of more than one H1 header.'
+$lang['ignore_todo-list'] = 'Ignore pages specifically marked with the "~~TODOLIST~~" macro for use with the ToDo plugin.'

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,3 +3,4 @@
 $lang['maxshowen'] = 'Maximum displayed pages on Quality Summary';
 $lang['adminonly'] = 'Quality Summary only visible for members of the admin group';
 $lang['single_author_only'] = 'There is only one or a few authors.';
+$lang['ignore_nobacklink'] = 'Ignore the scoring of missing backlinks. This might be applicable when the Alternative Breadcrumbs feature is providing a backlink each for all pages e.g., by the sprintdoc template'

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,4 @@ $lang['maxshowen'] = 'Maximum displayed pages on Quality Summary';
 $lang['adminonly'] = 'Quality Summary only visible for members of the admin group';
 $lang['single_author_only'] = 'There is only one or a few authors.';
 $lang['ignore_nobacklink'] = 'Ignore the scoring of missing backlinks. This might be applicable when the Alternative Breadcrumbs feature is providing a backlink each for all pages e.g., by the sprintdoc template'
+$lang['ignore_header_count'] = 'Ignore the scoring of more than one H1 header.'

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -5,5 +5,5 @@ $lang['adminonly'] = 'Quality Summary only visible for members of the admin grou
 $lang['single_author_only'] = 'There is only one or a few authors.';
 $lang['ignore_nobacklink'] = 'Ignore the scoring of missing backlinks. This might be applicable when the Alternative Breadcrumbs feature is providing a backlink each for all pages e.g., by the sprintdoc template'
 $lang['ignore_header_count'] = 'Ignore the scoring of more than one H1 header.'
-$lang['ignore_todo-list'] = 'Ignore pages specifically marked with the "~~TODOLIST~~" macro for use with the ToDo plugin.'
-$lang['ignore_sidebar'] = 'Ignore "sidebar" special page names.'
+$lang['skip_todo-list'] = 'Skip pages specifically marked with the "~~TODOLIST~~" macro for use with the ToDo plugin.'
+$lang['skip_sidebar'] = 'Skip "sidebar" special page names.'

--- a/renderer.php
+++ b/renderer.php
@@ -109,7 +109,7 @@ class renderer_plugin_qc extends Doku_Renderer
         }
         
         // 1 point for each H1 too much
-        if ($this->docArray['header_count'][1] > 1) {
+        if (!$this->getConf('ignore_header_count') && $this->docArray['header_count'][1] > 1) {
             $this->docArray['err']['manyh1'] += $this->docArray['header_count'][1];
         }
 

--- a/renderer.php
+++ b/renderer.php
@@ -96,7 +96,7 @@ class renderer_plugin_qc extends Doku_Renderer
         global $ID;
 
         // 2 points for missing backlinks
-        if (ft_backlinks($ID) === []) {
+        if (!$this->getConf('ignore_nobacklink') && ft_backlinks($ID) === []) {
             $this->docArray['err']['nobacklink'] += 2;
         }
 
@@ -107,9 +107,10 @@ class renderer_plugin_qc extends Doku_Renderer
         if ($this->docArray['header_count'][1] == 0) {
             $this->docArray['err']['noh1'] += 5;
         }
+        
         // 1 point for each H1 too much
         if ($this->docArray['header_count'][1] > 1) {
-            $this->docArray['err']['manyh1'] += $this->docArray['header'][1];
+            $this->docArray['err']['manyh1'] += $this->docArray['header_count'][1];
         }
 
         // 1 point for each incorrectly nested headline
@@ -125,7 +126,7 @@ class renderer_plugin_qc extends Doku_Renderer
             $this->docArray['err']['deepquote'] = $this->docArray['quote_nest'] / 2;
         }
 
-        // FIXME points for many quotes?
+        // FIXME points for too many quotes?
 
         // 1/2 points for too many hr
         if ($this->docArray['hr'] > 2) {

--- a/syntax.php
+++ b/syntax.php
@@ -33,7 +33,7 @@ class syntax_plugin_qc extends SyntaxPlugin
     {
         $this->Lexer->addSpecialPattern('~~NOQC~~', $mode, 'plugin_qc');
         
-        if ($this->getConf('ignore_todo-list') {
+        if ($this->getConf('skip_todo-list') {
             $this->Lexer->addSpecialPattern('~~TODOLIST~~', $mode, 'plugin_qc');
         }
     }

--- a/syntax.php
+++ b/syntax.php
@@ -32,6 +32,10 @@ class syntax_plugin_qc extends SyntaxPlugin
     public function connectTo($mode)
     {
         $this->Lexer->addSpecialPattern('~~NOQC~~', $mode, 'plugin_qc');
+        
+        if ($this->getConf('ignore_todo-list') {
+            $this->Lexer->addSpecialPattern('~~TODOLIST~~', $mode, 'plugin_qc');
+        }
     }
 
     /** @inheritdoc */

--- a/syntax.php
+++ b/syntax.php
@@ -33,7 +33,7 @@ class syntax_plugin_qc extends SyntaxPlugin
     {
         $this->Lexer->addSpecialPattern('~~NOQC~~', $mode, 'plugin_qc');
         
-        if ($this->getConf('skip_todo-list') {
+        if ($this->getConf('skip_todo-list')) {
             $this->Lexer->addSpecialPattern('~~TODOLIST~~', $mode, 'plugin_qc');
         }
     }


### PR DESCRIPTION
applies several **flexibility improvements** as proposed by #57 

 - [new conf option 'ignore_nobacklink'](https://github.com/cosmocode/qc/pull/58/commits/11f4ee884645b1368521c06fc7c8e85e4c69dbb4), was point (2.)
 - [new conf option 'ignore_header_count'](https://github.com/cosmocode/qc/pull/58/commits/aa3656605d6e8c0e50cb212b8030ba4da32e8237), was point (5.)
 - [new conf option 'skip_todo-list'](https://github.com/cosmocode/qc/pull/58/commits/c5ac4178242dfd7c751a957e2efe1332c382ad1d), was point (4.) - renamed
 - [new conf option 'skip_sidebar'](https://github.com/cosmocode/qc/pull/58/commits/557c2528d3ef3a5f37f794a04ec15fd88902e7a3), was point (3.) - renamed

Late decision to differentiate between _ignoring_ particular scores and _skipping_ pages completely thus changing the names accordingly.