### PR TITLE
new config option 'skip_specials'

### DIFF
--- a/README
+++ b/README
@@ -24,4 +24,4 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
-See the LICENSING file for details
+See the LICENSE file for details

--- a/admin.php
+++ b/admin.php
@@ -78,9 +78,14 @@ class admin_plugin_qc extends AdminPlugin
             $this->getLang('admin_fixme') . '</a></th>';
         echo '  </tr>';
 
+        $skip = $this->getConf('skip_specials');
+
         if ($this->data) {
             foreach ($this->data as $id => $data) {
                 if ($max == 0) break;
+                if ($skip && ($id === 'sidebar' || str_ends_with($id, ':sidebar') || str_ends_with($id, '_template'))) {
+                    continue;  // skips 'sidebar' & '_template'. '__template', 'c_template', 'i_template' special pages
+                }
                 echo '  <tr>';
                 echo '    <td>';
                 tpl_pagelink(':' . $id, $id);

--- a/conf/default.php
+++ b/conf/default.php
@@ -3,3 +3,4 @@
 $conf['maxshowen'] = '25';
 $conf['adminonly'] = 0;
 $conf['single_author_only'] = 0;
+$conf['skip_specials'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,3 +3,4 @@
 $meta['maxshowen'] = array('numeric');
 $meta['adminonly'] = array('onoff');
 $meta['single_author_only'] = array('onoff');
+$meta['skip_specials'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,3 +3,4 @@
 $lang['maxshowen'] = 'Maximum displayed pages on Quality Summary';
 $lang['adminonly'] = 'Quality Summary only visible for members of the admin group';
 $lang['single_author_only'] = 'There is only one or a few authors.';
+$lang['skip_specials'] = 'Skip special "sidebar" & "[c|i]_template" pages. Deselect for e.g., scores of "some-other_template" pages.';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,7 +2,7 @@
 base   qc
 author Andreas Gohr
 email  dokuwiki@cosmocode.de
-date   2023-12-02
+date   2024-05-12
 name   Quality Control Plugin
 desc   Check the page structure for quality problems
-url    http://www.dokuwiki.org/plugin:qc
+url    https://www.dokuwiki.org/plugin:qc

--- a/renderer.php
+++ b/renderer.php
@@ -95,7 +95,7 @@ class renderer_plugin_qc extends Doku_Renderer
     {
         global $ID;
 
-        // 2 points for missing backlinks
+        // 2 points for missing i.e. no backlinks
         if (ft_backlinks($ID) === []) {
             $this->docArray['err']['nobacklink'] += 2;
         }
@@ -107,6 +107,7 @@ class renderer_plugin_qc extends Doku_Renderer
         if ($this->docArray['header_count'][1] == 0) {
             $this->docArray['err']['noh1'] += 5;
         }
+        
         // 1 point for each H1 too much
         if ($this->docArray['header_count'][1] > 1) {
             $this->docArray['err']['manyh1'] += $this->docArray['header_count'][1];
@@ -132,7 +133,7 @@ class renderer_plugin_qc extends Doku_Renderer
             $this->docArray['err']['manyhr'] = ($this->docArray['hr'] - 2) / 2;
         }
 
-        // 1 point for too many line breaks
+        // 1 point for too many forced line breaks
         if ($this->docArray['linebreak'] > 2) {
             $this->docArray['err']['manybr'] = $this->docArray['linebreak'] - 2;
         }


### PR DESCRIPTION
Skip special "sidebar" & "[c|i]_template" pages in Quality Report if conf was selected.
- establish conf and code accordingly
- some clarification in comments in 'renderer.php'
- some typo fix(es)

CAVEAT: Please extra check [plugin.info.txt](https://github.com/cosmocode/qc/compare/master...Zweihorn:dokuwiki-plugin-qc:flexibility-improv-001?expand=1#diff-f510296ec4c1c3840549ed46f5df5ac96c8d3bdb4c82916c0f2680c5da448256) as an old commit was included by me unfortunately.