### PR TITLE
Fix some warnings

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -67,7 +67,8 @@ class renderer_plugin_qc extends Doku_Renderer
         // get author info
         $changelog = new PageChangeLog($ID);
         $revs = $changelog->getRevisions(0, 10000); //FIXME find a good solution for 'get ALL revisions'
-        $revs[] = $meta['last_change']['date'];
+        $lastChange = $meta['last_change'] ?? null;
+        $revs[] = is_array($lastChange) ? ($lastChange['date'] ?? []) : [];
         $this->docArray['changes'] = count($revs);
         foreach ($revs as $rev) {
             $info = $changelog->getRevisionInfo($rev);

--- a/renderer.php
+++ b/renderer.php
@@ -44,7 +44,8 @@ class renderer_plugin_qc extends Doku_Renderer
             'manyhr' => 0,
             'manybr' => 0,
             'longformat' => 0,
-            'multiformat' => 0
+            'multiformat' => 0,
+            'nobacklink' => 0
         ],
     ];
 

--- a/renderer.php
+++ b/renderer.php
@@ -216,7 +216,7 @@ class renderer_plugin_qc extends Doku_Renderer
         // calculate link width
         $a = explode(':', getNS($ID));
         $b = explode(':', getNS($id));
-        while (isset($a[0]) && $a[0] === $b[0]) {
+        while (isset($a[0], $b[0]) && $a[0] === $b[0]) {
             array_shift($a);
             array_shift($b);
         }


### PR DESCRIPTION
Add some verification before accessing the array.
Resolving:
```txt
E_WARNING: Trying to access array offset on false/storage/lib/plugins/qc/renderer.php(70)
    #0 /storage/lib/plugins/qc/renderer.php(70): dokuwiki\ErrorHandler::errorHandler()
    #1 /var/www/html/inc/parserutils.php(691): renderer_plugin_qc->document_start()
    #2 /var/www/html/inc/parserutils.php(158): p_render()
    #3 /storage/lib/plugins/qc/helper.php(74): p_cached_output()
    #4 /storage/lib/plugins/qc/action/cron.php(69): helper_plugin_qc->getQCData()
    #5 /var/www/html/inc/Extension/EventHandler.php(80): action_plugin_qc_cron->qccron()
```

Add default value for `nobacklink` in `docArray`.
Resolving:
```txt
E_WARNING: Undefined array key "nobacklink"/storage/lib/plugins/qc/renderer.php(100)
    #0 /storage/lib/plugins/qc/renderer.php(100): dokuwiki\ErrorHandler::errorHandler()
    #1 /var/www/html/inc/parserutils.php(691): renderer_plugin_qc->document_end()
    #2 /var/www/html/inc/parserutils.php(158): p_render()
    #3 /storage/lib/plugins/qc/helper.php(74): p_cached_output()
    #4 /storage/lib/plugins/qc/action/cron.php(69): helper_plugin_qc->getQCData()
    #5 /var/www/html/inc/Extension/EventHandler.php(80): action_plugin_qc_cron->qccron()
```

Add check for second array if it is set in while loop as well.
Resolving:
```txt
E_WARNING: Undefined array key 0/storage/lib/plugins/qc/renderer.php(219)
    #0 /storage/lib/plugins/qc/renderer.php(219): dokuwiki\ErrorHandler::errorHandler()
    #1 /var/www/html/inc/parserutils.php(691): renderer_plugin_qc->internallink()
    #2 /var/www/html/inc/parserutils.php(158): p_render()
    #3 /storage/lib/plugins/qc/helper.php(74): p_cached_output()
    #4 /storage/lib/plugins/qc/action/cron.php(69): helper_plugin_qc->getQCData()
    #5 /var/www/html/inc/Extension/EventHandler.php(80): action_plugin_qc_cron->qccron()
```